### PR TITLE
Migrate Gemini integration to google-genai SDK

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ requests
 xai-sdk
 yfinance
 pandas
-google-generativeai
+google-genai


### PR DESCRIPTION
## Summary
- replace google-generativeai with google-genai
- refactor Gemini client usage to genai.Client with GenerateContentConfig and Google Search tool
- add response text extraction fallback so tool responses don't crash handlers

## Testing
- not run (API keys not available here)

Closes #9