### PR TITLE
Feature: Add 50/200 DMA to manage command market data

### DIFF
--- a/ai_engine.py
+++ b/ai_engine.py
@@ -102,8 +102,12 @@ def build_manage_prompt(trade: Dict, market: Dict) -> str:
             f"Expiry: {trade['expiry']} (Opened: {trade['date']})"
         )
 
+    dma_info = ""
+    if market.get('dma_50') != 'N/A' and market.get('dma_200') != 'N/A':
+        dma_info = f" 50-DMA: ${market['dma_50']:.2f}, 200-DMA: ${market['dma_200']:.2f}."
+
     return (
-        f"Manage {trade['ticker']}. {entry_info}. Current Market Price: ${market['price']}. "
+        f"Manage {trade['ticker']}. {entry_info}. Current Market Price: ${market['price']}.{dma_info} "
         f"Today: {datetime.now().strftime('%Y-%m-%d')}. "
         f"Calculate current profit/loss based on decay. "
         f"Evaluate 50% profit target and provide Net Credit Roll advice."

--- a/market_data.py
+++ b/market_data.py
@@ -51,6 +51,8 @@ def get_market_data(ticker_symbol: str) -> Dict[str, str]:
             "earnings": next_earnings,
             "iv_hint": info.get("beta", "N/A"),
             "sector": info.get("sector", "Unknown"),
+            "dma_50": info.get("fifty_day_average", "N/A"),
+            "dma_200": info.get("two_hundred_day_average", "N/A"),
         }
 
     except Exception as e:


### PR DESCRIPTION
## Enhancement
Adds 50-day and 200-day moving averages to the market data sent to the AI when running /manage commands.

## Changes
- **market_data.py**: Fetches fifty_day_average and two_hundred_day_average from yfinance
- **ai_engine.py**: Includes DMA data in AI prompt for better roll recommendations

## Value to AI
The AI now has technical context when recommending rolls:
- 50-DMA: Short-term support/resistance
- 200-DMA: Long-term trend indicator
- Helps identify if current price is near key technical levels

## Example Output
Before: 'Current Market Price: $322. Calculate profit/loss...'
After: 'Current Market Price: $322. 50-DMA: $318.50, 200-DMA: $298.20. Calculate profit/loss...'